### PR TITLE
Missing "process" dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "chokidar": "^1.6.1",
     "colors": "^1.1.2",
     "commander": "^2.9.0",
-    "node-notifier": "^4.6.1"
+    "node-notifier": "^4.6.1",
+    "process": "^0.5.1"
   }
 }


### PR DESCRIPTION
### Description
On systems where the npm package "process" is not preinstalled the execution of the programm will cause an error:
```
D:\Repositories\test>php-qa-watch -w "phpunit.xml.dist,phpcs.xml,modules/**/*.php,test/**/*.php"
module.js:338
    throw err;
          ^
Error: Cannot find module 'process'
    at Function.Module._resolveFilename (module.js:336:15)
    at Function.Module._load (module.js:278:25)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (C:\Users\Tobias Trozowski\AppData\Roaming\npm\node_modules\phly-php-qa-watch\index.js:29:11)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Function.Module.runMain (module.js:501:10)
```

### Fixed issues
- #3 added missing dependency "process" to package.json

