### PR TITLE
process.env.PWD is undefined on Windows OS

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ var exec = require('child_process').exec;
 var program = require('commander');
 var notifier = require('node-notifier');
 
-var pwd = require('process').env.PWD;
+var pwd = require('process').env.PWD || require('process').cwd();
 var project = require('path').posix.basename(pwd);
 var errorIcon = __dirname + '/error.png';
 var defaultWatchFiles = ['phpunit.xml.dist', 'phpcs.xml', 'src/**/*.php', 'test/**/*.php'];


### PR DESCRIPTION
### Description
On windows systems ```process.env.PWD``` is ```undefined```:
```
D:\Repositories\test>php-qa-watch -w "phpunit.xml.dist,phpcs.xml,modules/**/*.php"
[2016-12-30T14:21:04.124Z] Watching undefined
```

### Fixed issues
- #4 added alternative when process.env.PWD is undefined

